### PR TITLE
Fixed the problem of displaying the model from a third person after its issuance.

### DIFF
--- a/sourcemod/scripting/customweapons/api.sp
+++ b/sourcemod/scripting/customweapons/api.sp
@@ -146,6 +146,7 @@ any Native_SetModel(Handle plugin, int numParams)
 		case CustomWeaponModel_World:
 		{
 			custom_weapon_data.world_model = source;
+			ReEquipWeaponEntity(entity);
 		}
 		case CustomWeaponModel_Dropped:
 		{


### PR DESCRIPTION
When installing skins on weapons in `SDKHook_WeaponEquip`, a bug was noticed that the third-person model was not displayed, but if you throw out the weapon, you can immediately see the new model (in flight), which indicates a bug from the core. But if you set the model not in this hook, "in the middle of the round", then there is no bug.

After I set the model in my plugin through one `RequestFrame()` frame, in the same hook, this bug does not occur. After that, I removed it in my plugin and went to fix the core, and surprisingly, a simple "reissue" of the weapon solved the problem, which is why I made this `pull request`.