### PR TITLE
Attempt to fix an invalid handle when the player exits

### DIFF
--- a/sourcemod/scripting/customweapons.sp
+++ b/sourcemod/scripting/customweapons.sp
@@ -109,12 +109,6 @@ void Hook_OnWeaponSwitchPost(int client, int weapon)
 	SoundsMgr_OnWeaponSwitchPost(client, weapon);
 }
 
-public void OnClientDisconnect(int client)
-{
-	// Frees the slot data.
-	g_Players[client].Close();
-}
-
 bool IsEntityWeapon(int entity)
 {
 	// Retrieve the entity classname.

--- a/sourcemod/scripting/customweapons/soundsmgr.sp
+++ b/sourcemod/scripting/customweapons/soundsmgr.sp
@@ -64,16 +64,13 @@ void CreateToggleDefaultSoundsTimer(int client, bool value)
 Action Timer_ToggleDefaultSounds(Handle timer, DataPack dp)
 {
 	int client = GetClientOfUserId(dp.ReadCell());
-	if (!client)
+	if (client)
 	{
-		return Plugin_Continue;
+		g_Players[client].toggle_sounds_timer = null;
+		g_Players[client].ToggleDefaultShotSounds(dp.ReadCell());
 	}
-	
-	g_Players[client].toggle_sounds_timer = null;
-	
-	g_Players[client].ToggleDefaultShotSounds(dp.ReadCell());
-	
-	return Plugin_Continue;
+
+	return Plugin_Stop;
 }
 
 // Server side.

--- a/sourcemod/scripting/customweapons/structs.sp
+++ b/sourcemod/scripting/customweapons/structs.sp
@@ -29,15 +29,7 @@ enum struct Player
 		
 		this.default_sounds_enabled = true;
 	}
-	
-	void Close()
-	{
-		this.view_model_reference = 0;
-		this.default_sounds_enabled = false;
-		
-		delete this.toggle_sounds_timer;
-	}
-	
+
 	void InitViewModel()
 	{
 		this.view_model_reference = EntIndexToEntRef(GetEntPropEnt(this.client, Prop_Send, "m_hViewModel"));


### PR DESCRIPTION
When a player logged out, if he had a weapon with a modified sound, the following error came across:
```css
L 07/18/2022 - 18:55:24: [SM] Exception reported: Handle 56801961 is invalid (error 1)
L 07/18/2022 - 18:55:24: [SM] Blaming: custom_weapons_for_tlou\customweapons.smx
L 07/18/2022 - 18:55:24: [SM] Call stack trace:
L 07/18/2022 - 18:55:24: [SM]   [0] CloseHandle
L 07/18/2022 - 18:55:24: [SM]   [1] Line 38, customweapons\structs.sp::Close
L 07/18/2022 - 18:55:24: [SM]   [2] Line 115, C:\ze_server_csgo\csgo\addons\sourcemod\scripting\customweapons.sp::OnClientDisconnect
L 07/18/2022 - 18:55:27: Error log file session closed.
```

### I don't see the need to reset the exited player's data, because:

1.  The timer is "one-time", it will close itself anyway
https://github.com/KoNLiG/customweapons/blob/b0944e610d4fb123a1363c139d162af2270ab4ec/sourcemod/scripting/customweapons/soundsmgr.sp#L64-L77

2.  When a player logs in, we overwrite the old data with the new one
https://github.com/KoNLiG/customweapons/blob/b0944e610d4fb123a1363c139d162af2270ab4ec/sourcemod/scripting/customweapons/structs.sp#L25-L31

But I have doubts about this handle closure, it would not hurt to check its condition. What is your opinion about this?
`delete` does not reset the variable if it is a timer - checked more than once, after `delete timer_handle` you should always do `timer_handle = INVALID_HANDLE`
https://github.com/KoNLiG/customweapons/blob/b0944e610d4fb123a1363c139d162af2270ab4ec/sourcemod/scripting/customweapons/soundsmgr.sp#L53-L54